### PR TITLE
better-assert should be a dev-Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "utility"
   ],
   "dependencies": {
-    "better-assert": "~0.1.0"
   },
   "devDependencies": {
     "mocha": "*",
-    "should": "*"
+    "should": "*",
+    "better-assert": "*"
   },
   "component": {
     "scripts": {


### PR DESCRIPTION
This massively reduces the download size for npm
