### PR TITLE
add support for complex expressions and implicit getter-style functions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -61,7 +61,7 @@ var users = [
   { name: { first: 'Jane' }, age: 6 }
 ];
 
-var oldPets = users.filter(_('age > 2'));
+var oldPets = users.filter(_('age > 2 && age < 10'));
 console.log(oldPets);
 // => [ { name: { first: 'Jane' }, age: 6 } ]
 ```

--- a/component.json
+++ b/component.json
@@ -4,7 +4,9 @@
   "description": "Convert property access strings into functions",
   "version": "1.1.1",
   "keywords": ["utility", "function"],
-  "dependencies": {},
+  "dependencies": {
+    "component/props": "*"
+  },
   "development": {},
   "scripts": [
     "index.js"

--- a/index.js
+++ b/index.js
@@ -1,3 +1,12 @@
+/**
+ * Module Dependencies
+ */
+
+try {
+  var expr = require('props');
+} catch(e) {
+  var expr = require('props-component');
+}
 
 /**
  * Expose `toFunction()`.
@@ -68,8 +77,8 @@ function stringToFunction(str) {
   // immediate such as "> 20"
   if (/^ *\W+/.test(str)) return new Function('_', 'return _ ' + str);
 
-  // properties such as "name.first" or "age > 18"
-  return new Function('_', 'return _.' + str);
+  // properties such as "name.first" or "age > 18" or "age > 18 && age < 36"
+  return new Function('_', 'return ' + get(str));
 }
 
 /**
@@ -95,4 +104,26 @@ function objectToFunction(obj) {
     }
     return true;
   }
+}
+
+/**
+ * Built the getter function. Supports getter style functions
+ *
+ * @param {String} str
+ * @return {String}
+ * @api private
+ */
+
+function get(str) {
+  var props = expr(str);
+  if (!props.length) return '_.' + str;
+
+  var val;
+  for(var i = 0, prop; prop = props[i]; i++) {
+    val = '_.' + prop;
+    val = "('function' == typeof " + val + " ? " + val + "() : " + val + ")";
+    str = str.replace(new RegExp(prop, 'g'), val);
+  }
+
+  return str;
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "keywords": [
     "utility"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "props-component": "*"
+  },
   "devDependencies": {
     "mocha": "*",
     "should": "*",

--- a/test/index.js
+++ b/test/index.js
@@ -26,10 +26,34 @@ describe('toFunction(str)', function(){
     assert(false === fn({ age: 18 }));
   })
 
+  it('should support complex js expressions', function(){
+    var fn = toFunction('age > 18 && age < 35');
+    assert(true === fn({ age: 20 }));
+    assert(false === fn({ age: 18 }));
+  })
+
   it('should support js with immediate value', function(){
     var fn = toFunction('> 18');
     assert(true === fn(20));
     assert(false === fn(18));
+  })
+
+  it('should support js with getter-style functions', function(){
+    var user = { attrs: { age: 24 }};
+    user.age = function(){ return this.attrs.age };
+    var fn = toFunction('age > 25');
+    assert(false == fn(user));
+    var fn = toFunction('age > 20');
+    assert(true == fn(user));
+  })
+
+  it('should support complex js expressions with getter-style functions', function(){
+    var user = { attrs: { age: 24 }};
+    user.age = function(){ return this.attrs.age };
+    var fn = toFunction('age > 30 || age < 20');
+    assert(false == fn(user));
+    var fn = toFunction('age > 20 && age < 35');
+    assert(true == fn(user));
   })
 })
 


### PR DESCRIPTION
This PR adds support for:
- complex expressions: `age > 2 && age < 10`
- implicit getter-style functions

```
age >= 25 && age < 35
```

Compiles to: 

```
('function' == typeof _.age ? _.age() : _.age) >= 25 && ('function' == typeof _.age ? _.age() : _.age) < 35 
```

Basically allowing for an object to have `obj.age` or `obj.age()`.
