### PR TITLE
Add node support for component-props.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 /**
  * Module Dependencies
  */
-
-var expr = require('props');
+try {
+  var expr = require('props');
+} catch(e) {
+  var expr = require('component-props');
+}
 
 /**
  * Expose `toFunction()`.


### PR DESCRIPTION
Reverts @retrofox's change to re-enable support in node: https://github.com/component/to-function/commit/014d5059b1c85b23e49c71ea0ffe663fc47b3c3d

This component/npm name mismatch thing entirely sucks for everyone.
