### PR TITLE
Revert "Remove unused dependency"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "utility"
   ],
   "dependencies": {
-    "component-props": "*"
+    "component-props": "*",
+    "remove-try-require": "0.0.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
Reverts component/to-function#16

It is used actually, in the `browserify.transform` field of the package.json file here. The dependency needs to be present for that part to work.
